### PR TITLE
Launch noVNC at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Test Skin Patches
 An automated tool to be used during production stage for testing skin patches.
 
 ## Instructions to run the container
-Install [Docker](https://www.docker.com) and go through the following steps:
+Install [Docker](https://www.docker.com) and make sure to go through these [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/) on Linux systems.
+
+Once you have Docker properly installed, follow these instructions:
 1. Pull the docker image:
     ```sh
     $ docker pull ghcr.io/icub-tech-iit/test-skin-patches:latest

--- a/README.md
+++ b/README.md
@@ -11,14 +11,18 @@ Install [Docker](https://www.docker.com) and go through the following steps:
     ```
 2. Launch the container:
     ```sh
-    $ docker run -it --rm --network host ghcr.io/icub-tech-iit/test-skin-patches:latest
+    $ docker run --name test_skin --rm --network host ghcr.io/icub-tech-iit/test-skin-patches:latest
     ```
-3. From within the container shell, launch the following scripts:
+3. Open up the browser and connect to **`localhost:6080`** to get to the workspace desktop GUI.
+5. Once done, stop the container:
     ```sh
-    $ start-vnc-session.sh
+    $ docker stop test_skin
     ```
-4. Open up the browser and connect to **`localhost:6080`** to get to the workspace desktop GUI.
-5. Once done, from the container shell press **CTRL+D**.
+
+⚠ In case the desktop GUI stops working, you can start it over:
+```sh
+$ docker exec test_skin start-vnc-session.sh
+```
 
 ### 👨🏻‍💻 Maintainers
 This repository is maintained by:

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -90,4 +90,4 @@ RUN rm -Rf /var/lib/apt/lists/*
 
 # Launch bash from /workspace
 WORKDIR /workspace
-CMD ["bash"]
+ENTRYPOINT ["start-vnc-session.sh && bash"]

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -90,4 +90,4 @@ RUN rm -Rf /var/lib/apt/lists/*
 
 # Launch bash from /workspace
 WORKDIR /workspace
-ENTRYPOINT ["start-vnc-session.sh && bash"]
+ENTRYPOINT ["/usr/bin/start-vnc-session.sh && bash"]


### PR DESCRIPTION
This PR allows for launching automatically `start-vnc-sessions.sh` when a container gets spawned.

Also, we no longer need the container shell, so we propose not to rely on the option `-it`.